### PR TITLE
textEditorWidget: Make CodeMirror Key map customizable from settings

### DIFF
--- a/textEditorWidget/data/TextEditorSettingsResource.ts
+++ b/textEditorWidget/data/TextEditorSettingsResource.ts
@@ -1,6 +1,7 @@
 interface TextEditorSettingsResourcePub {
   tabSize: number;
   softTab: boolean;
+  keyMap: string;
 }
 
 export default class TextEditorSettingsResource extends SupCore.Data.Base.Resource {
@@ -8,6 +9,7 @@ export default class TextEditorSettingsResource extends SupCore.Data.Base.Resour
   static schema: SupCore.Data.Schema = {
     tabSize: { type: "number", min: 1, mutable: true },
     softTab: { type: "boolean", mutable: true },
+    keyMap: { type: "enum", items: [ "sublime", "emacs", "vim" ], mutable: true }
   };
 
   pub: TextEditorSettingsResourcePub;
@@ -19,7 +21,8 @@ export default class TextEditorSettingsResource extends SupCore.Data.Base.Resour
   init(callback: Function) {
     this.pub = {
       tabSize: 2,
-      softTab: true
+      softTab: true,
+      keyMap: "sublime"
     };
 
     super.init(callback);

--- a/textEditorWidget/public/locales/en/settingsEditors.json
+++ b/textEditorWidget/public/locales/en/settingsEditors.json
@@ -2,6 +2,7 @@
   "TextEditor": {
     "label": "Text Editor",
     "tabSize": "Tab size",
-    "useSoftTab": "Use soft tab"
+    "useSoftTab": "Use soft tab",
+    "keyMap": "Key map"
   }
 }

--- a/textEditorWidget/settingsEditors/TextEditorSettingsEditor.ts
+++ b/textEditorWidget/settingsEditors/TextEditorSettingsEditor.ts
@@ -5,6 +5,7 @@ export default class TextEditorSettingsEditor {
 
   tabSizeField: HTMLInputElement;
   softTabField: HTMLInputElement;
+  keyMapField: HTMLSelectElement;
 
   constructor(container: HTMLDivElement, projectClient: SupClient.ProjectClient) {
     let { tbody } = SupClient.table.createTable(container);
@@ -21,6 +22,12 @@ export default class TextEditorSettingsEditor {
       projectClient.editResource("textEditorSettings", "setProperty", "softTab", event.target.checked);
     });
 
+    let keyMapRow = SupClient.table.appendRow(tbody, SupClient.i18n.t("settingsEditors:TextEditor.keyMap"));
+    this.keyMapField = SupClient.table.appendSelectBox(keyMapRow.valueCell, { "sublime": "Sublime", "emacs": "Emacs", "vim": "Vim" }, "sublime");
+    this.keyMapField.addEventListener("change", (event: any) => {
+      projectClient.editResource("textEditorSettings", "setProperty", "keyMap", event.target.value);
+    });
+
     projectClient.subResource("textEditorSettings", this);
   }
 
@@ -29,12 +36,14 @@ export default class TextEditorSettingsEditor {
 
     this.tabSizeField.value = resource.pub.tabSize.toString();
     this.softTabField.checked = resource.pub.softTab;
+    this.keyMapField.value = resource.pub.keyMap;
   };
 
   onResourceEdited = (resourceId: string, command: string, propertyName: string) => {
     switch(propertyName) {
       case "tabSize": this.tabSizeField.value = this.resource.pub.tabSize.toString(); break;
       case "softTab": this.softTabField.checked = this.resource.pub.softTab; break;
+      case "keyMap": this.keyMapField.value = this.resource.pub.keyMap; break;
     }
   };
 }

--- a/textEditorWidget/widget/widget.ts
+++ b/textEditorWidget/widget/widget.ts
@@ -11,6 +11,8 @@ require("codemirror/addon/comment/comment");
 require("codemirror/addon/hint/show-hint");
 require("codemirror/addon/selection/active-line");
 require("codemirror/keymap/sublime");
+require("codemirror/keymap/emacs");
+require("codemirror/keymap/vim");
 require("codemirror/addon/fold/foldcode");
 require("codemirror/addon/fold/foldgutter");
 require("codemirror/addon/fold/brace-fold");
@@ -361,6 +363,7 @@ class TextEditorWidget {
     this.codeMirrorInstance.setOption("tabSize", resource.pub.tabSize);
     this.codeMirrorInstance.setOption("indentUnit", resource.pub.tabSize);
     this.codeMirrorInstance.setOption("indentWithTabs", !resource.pub.softTab);
+    this.codeMirrorInstance.setOption("keyMap", resource.pub.keyMap);
     this.useSoftTab = resource.pub.softTab;
   };
 
@@ -374,6 +377,8 @@ class TextEditorWidget {
         this.useSoftTab = this.textEditorResource.pub.softTab;
         this.codeMirrorInstance.setOption("indentWithTabs", !this.textEditorResource.pub.softTab);
         break;
+      case "keyMap":
+        this.codeMirrorInstance.setOption("keyMap", this.textEditorResource.pub.keyMap);
     }
   };
 }


### PR DESCRIPTION
Hello!

First of all, I've been using CraftStudio while it was still being developed and I'm really happy that you've decided to make your new game making engine open source.

Let me get to the business. [One of the reddit users](https://www.reddit.com/r/superpowers/comments/4mogh9/superpowers_editor_vim_mode/) requested the key map option of CodeMirror to be editable from the client interface, so I've decided to go and take a look into the code. This is working, you can choose the keymap in the settings between Sublime, Emacs and Vim.

But I'd like you to take a look at [these lines](https://github.com/superpowers/superpowers-common-plugins/commit/b6cb6d41806deb354537e7ae224f7496884bcf70#diff-96b2c993349529a01339dcbdbb90dd08R14). Basically, I'm loading all three keymaps and then switching between them if needed. I figured that it would be ok, since it's done once when the server loads, but I'm not sure. Is it OK or should we load the needed keymap file dynamically?
