### PR TITLE
textEditorWidget: Add key mapping for findPersistent

### DIFF
--- a/textEditorWidget/widget/widget.ts
+++ b/textEditorWidget/widget/widget.ts
@@ -62,7 +62,8 @@ class TextEditorWidget {
       "Shift-Ctrl-Z": () => { this.redo(); },
       "Shift-Cmd-Z": () => { this.redo(); },
       "Ctrl-Y": () => { this.redo(); },
-      "Cmd-Y": () => { this.redo(); }
+      "Cmd-Y": () => { this.redo(); },
+      "Alt-F": "findPersistent"
     };
     if (options.extraKeys != null) {
       for (const keyName in options.extraKeys) {


### PR DESCRIPTION
Following [this discussion](https://itch.io/t/34518/a-little-detail-about-search).

Hello!
This adds the CodeMirror's "findPersistent" function (not bound by default), where the search dialog stays visible and focus. It allows a faster searching, and the possibility to do several searches in a row.

The chosen keys combination is "Alt-F", since it's the one used in the [CodeMirror demo](https://codemirror.net/demo/search.html). Most of the other "search related" keys combinations seem to be already taken.

Now, if we would go even further, I wonder if adding an option to replace the default search by this one would be relevant? I'm not sure though if there would be a way to express it in the GUI without being confusing.
